### PR TITLE
Add toggle to allow build to pass even if slack api is down.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Configuration
 |Icon or Emoji|The icon URL or Slack emoji (e.g. - `https://example.org/icon.png` or `:tada:`)|No|
 |Color|The color label for the message displayed as a bar on the side. Select `custom` to define any color|Yes|
 |Custom color|Defines a custom color as a three or six-hex digit code without `#` (e.g. - `ff0000` for red).|If using custom color|
+|Fail on error|Whether the build should fail if an issue occurs when contacting Slack|No|
 
 ### Environment Variables and Parameters
 

--- a/src/main/java/com/vincit/go/task/slack/SlackTaskPlugin.java
+++ b/src/main/java/com/vincit/go/task/slack/SlackTaskPlugin.java
@@ -82,32 +82,38 @@ public class SlackTaskPlugin extends AbstractTaskPlugin {
         TaskConfig executionRequest = jsonUtil.fromJSON(request.requestBody(), TaskConfig.class);
         Context context = executionRequest.getContext();
 
+        EnvVarReplacer envVarReplacer = new EnvVarReplacer(context.getEnvironmentVariables());
+
+        Config config = executionRequest.getConfig()
+                .replace(envVarReplacer);
+
+        String webhookUrl = config.getWebhookUrl();
+
+        TaskSlackMessage message = new TaskSlackMessage(
+                config.getDisplayName(),
+                config.getTitle(),
+                config.getMessage(),
+                config.getIconOrEmoji(),
+                config.getColor(),
+                config.getMarkdownIns()
+        );
+
+        TaskSlackDestination destination = new TaskSlackDestination(
+                webhookUrl,
+                config.getChannelType(),
+                config.getChannel()
+        );
+
         try {
-            EnvVarReplacer envVarReplacer = new EnvVarReplacer(context.getEnvironmentVariables());
-
-            Config config = executionRequest.getConfig()
-                    .replace(envVarReplacer);
-
-            String webhookUrl = config.getWebhookUrl();
-
-            TaskSlackMessage message = new TaskSlackMessage(
-                    config.getDisplayName(),
-                    config.getTitle(),
-                    config.getMessage(),
-                    config.getIconOrEmoji(),
-                    config.getColor(),
-                    config.getMarkdownIns()
-            );
-
-            TaskSlackDestination destination = new TaskSlackDestination(
-                    webhookUrl,
-                    config.getChannelType(),
-                    config.getChannel()
-            );
 
             slackExecutorFactory.forDestination(destination).sendMessage(message);
+
         } catch (IOException e) {
-            throw new RuntimeException("Could not send message to slack", e);
+            if(config.getFailOnError().equals("true")) {
+                throw new RuntimeException("Could not send message to slack", e);
+            } else {
+                logger.error("Could not send message to slack: " + e.getMessage());
+            }
         }
 
         Map<String, Object> result = new HashMap<>();

--- a/src/main/java/com/vincit/go/task/slack/config/ConfigProvider.java
+++ b/src/main/java/com/vincit/go/task/slack/config/ConfigProvider.java
@@ -22,6 +22,7 @@ public class ConfigProvider {
     public static final String COLOR = "Color";
     public static final String COLOR_TYPE = "ColorType";
     public static final String MARKDOWN_IN_TEXT = "MarkdownInText";
+    public static final String FAIL_ON_ERROR = "FailOnError";
 
     private static Map<String, HashMap<String, Object>> fieldConfig = new HashMap<>();
 
@@ -36,6 +37,7 @@ public class ConfigProvider {
         fieldConfig.put(COLOR_TYPE, createField(ColorType.NONE.getDisplayValue(), Secure.NO, Required.YES));
         fieldConfig.put(COLOR, createField("", Secure.NO, Required.NO));
         fieldConfig.put(MARKDOWN_IN_TEXT, createField("", Secure.NO, Required.NO));
+        fieldConfig.put(FAIL_ON_ERROR, createField("", Secure.NO, Required.NO));
     }
 
     public static Map<String, ?> getFieldConfig() {

--- a/src/main/java/com/vincit/go/task/slack/model/Config.java
+++ b/src/main/java/com/vincit/go/task/slack/model/Config.java
@@ -4,6 +4,7 @@ import com.google.gson.annotations.SerializedName;
 import com.vincit.go.task.slack.config.ConfigProvider;
 import com.vincit.go.task.slack.utils.EnvVarReplacer;
 
+import java.sql.PreparedStatement;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -35,11 +36,15 @@ public class Config {
     private Property color;
     @SerializedName("MarkdownInText")
     private Property markdownInText;
+    @SerializedName("FailOnError")
+    private Property failOnError;
 
     public Config() {
     }
 
-    public Config(Property webhookUrl, Property channel, Property channelType, Property displayName, Property title, Property message, Property iconOrEmoji, Property colorType, Property color, Property markdownInText) {
+    public Config(Property webhookUrl, Property channel, Property channelType, Property displayName, Property title,
+                  Property message, Property iconOrEmoji, Property colorType, Property color, Property markdownInText,
+                  Property failOnError) {
         this.message = message;
         this.title = title;
         this.iconOrEmoji = iconOrEmoji;
@@ -50,6 +55,7 @@ public class Config {
         this.colorType = colorType;
         this.color = color;
         this.markdownInText = markdownInText;
+        this.failOnError = failOnError;
     }
 
     private String getValueOr(Property property, String value) {
@@ -165,6 +171,10 @@ public class Config {
         return markdownIns;
     }
 
+    public String getFailOnError() {
+        return getValueOr(failOnError, "");
+    }
+
     private void addFieldIfSet(Property property, MarkdownField field, Set<MarkdownField> ins) {
         if (property != null && property.isPresent() && Boolean.valueOf(property.getValueOr("false"))) {
             ins.add(field);
@@ -182,7 +192,8 @@ public class Config {
                 iconOrEmoji.replace(envVarReplacer),
                 colorType,
                 color.replace(envVarReplacer),
-                markdownInText
+                markdownInText,
+                failOnError
         );
     }
 }

--- a/src/main/java/com/vincit/go/task/slack/model/Config.java
+++ b/src/main/java/com/vincit/go/task/slack/model/Config.java
@@ -4,7 +4,6 @@ import com.google.gson.annotations.SerializedName;
 import com.vincit.go.task.slack.config.ConfigProvider;
 import com.vincit.go.task.slack.utils.EnvVarReplacer;
 
-import java.sql.PreparedStatement;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;

--- a/src/main/resources/views/task.template.html
+++ b/src/main/resources/views/task.template.html
@@ -96,6 +96,21 @@
   </span>
 </div>
 <div class="form_item_block">
+  <div class="checkbox_row">
+    <input id="failOnError" type="checkbox" ng-model="cbFailOnError"
+           ng-init="cbFailOnError = FailOnError"
+           ng-change="FailOnError = cbFailOnError"
+           ng-true-value="true" ng-false-value="false">
+    <input type="hidden" value="{{FailOnError}}" ng-model="FailOnError">
+    <label for="failOnError">
+      Fail the build if an error occurred while messaging slack.
+    </label>
+  </div>
+  <span class="form_error" ng-show="GOINPUTNAME[FailOnError].$error.server">
+    {{ GOINPUTNAME[FailOnError].$error.server }}
+  </span>
+</div>
+<div class="form_item_block">
   <label for="Color">Custom Color<span class="asterisk" ng-show="ColorType == 'Custom'">*</span></label>
   <div class="path_textbox">
     <label for="Color">#</label><input type="text" id="Color" ng-model="Color" ng-disabled="ColorType != 'Custom'">

--- a/src/main/resources/views/task.template.html
+++ b/src/main/resources/views/task.template.html
@@ -96,21 +96,6 @@
   </span>
 </div>
 <div class="form_item_block">
-  <div class="checkbox_row">
-    <input id="failOnError" type="checkbox" ng-model="cbFailOnError"
-           ng-init="cbFailOnError = FailOnError"
-           ng-change="FailOnError = cbFailOnError"
-           ng-true-value="true" ng-false-value="false">
-    <input type="hidden" value="{{FailOnError}}" ng-model="FailOnError">
-    <label for="failOnError">
-      Fail the build if an error occurred while messaging slack.
-    </label>
-  </div>
-  <span class="form_error" ng-show="GOINPUTNAME[FailOnError].$error.server">
-    {{ GOINPUTNAME[FailOnError].$error.server }}
-  </span>
-</div>
-<div class="form_item_block">
   <label for="Color">Custom Color<span class="asterisk" ng-show="ColorType == 'Custom'">*</span></label>
   <div class="path_textbox">
     <label for="Color">#</label><input type="text" id="Color" ng-model="Color" ng-disabled="ColorType != 'Custom'">
@@ -118,4 +103,20 @@
       {{ GOINPUTNAME[Color].$error.server }}
     </span>
   </div>
+</div>
+<div class="form_item_block">
+  <label>Error Handling</label>
+  <div class="checkbox_row">
+    <input id="failOnError" type="checkbox" ng-model="cbFailOnError"
+           ng-init="cbFailOnError = FailOnError"
+           ng-change="FailOnError = cbFailOnError"
+           ng-true-value="true" ng-false-value="false">
+    <input type="hidden" value="{{FailOnError}}" ng-model="FailOnError">
+    <label for="failOnError">
+      Fail the build if an error occurred while notifying Slack.
+    </label>
+  </div>
+  <span class="form_error" ng-show="GOINPUTNAME[FailOnError].$error.server">
+    {{ GOINPUTNAME[FailOnError].$error.server }}
+  </span>
 </div>

--- a/src/test/java/com/vincit/go/task/slack/model/ConfigTest.java
+++ b/src/test/java/com/vincit/go/task/slack/model/ConfigTest.java
@@ -241,15 +241,15 @@ public class ConfigTest {
     }
 
     private Config configWithColor(String colorType, String color) {
-        return new Config(prop(null), prop(null), prop(null), prop(null), prop(null), prop(null), prop(null), prop(colorType), prop(color), prop(null));
+        return new Config(prop(null), prop(null), prop(null), prop(null), prop(null), prop(null), prop(null), prop(colorType), prop(color), prop(null), prop(null));
     }
 
     private Config configWithChannel(String channelType, String channel) {
-        return new Config(prop(null), prop(channel), prop(channelType), prop(null), prop(null), prop(null), prop(null), prop(null), prop(null), prop(null));
+        return new Config(prop(null), prop(channel), prop(channelType), prop(null), prop(null), prop(null), prop(null), prop(null), prop(null), prop(null), prop(null));
     }
 
     private Config configWithTextMarkdownIn() {
-        return new Config(prop(null), prop(null), prop(null), prop(null), prop(null), prop(null), prop(null), prop(null), prop(null), prop("true"));
+        return new Config(prop(null), prop(null), prop(null), prop(null), prop(null), prop(null), prop(null), prop(null), prop(null), prop("true"), prop(null));
     }
 
     private Property prop(String value) {


### PR DESCRIPTION
Today for about 1 hour the slack API was down, this disabled all deployment and builds in our go pipelines that used this plugin. By allowing failure to be configured, admins can still demand that the message works if it is mission critical, but if it is just an extra feature it does not block deployments.